### PR TITLE
Add count-java-lines feature

### DIFF
--- a/src/main/java/com/elasticthree/ASTCreator/ASTCreator/ASTCreator.java
+++ b/src/main/java/com/elasticthree/ASTCreator/ASTCreator/ASTCreator.java
@@ -4,6 +4,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.log4j.Logger;
 import org.apache.log4j.PropertyConfigurator;
@@ -81,14 +82,14 @@ public class ASTCreator {
 
 	public static void main(String[] args) {
 		PropertyConfigurator.configure("resources/log4j.properties");
-		List<String> classes = RecursivelyProjectJavaFiles
+		Map<String, Long> classes = RecursivelyProjectJavaFiles
 				.getProjectJavaFiles(args[0]);
 		ASTCreator ast = new ASTCreator();
 		Neo4JDriver neo4j = new Neo4JDriver();
-		classes.forEach(file -> {
-			stdoutLog.info("-> Java File: " + file );
-			neo4j.insertNeo4JDB(ast.getASTStats(file));
-		});
+		for(String clazz: classes.keySet()) {
+			stdoutLog.info("-> Java File: " + clazz );
+			neo4j.insertNeo4JDB(ast.getASTStats(clazz));
+		}
 		neo4j.closeDriverSession();
 
 	}

--- a/src/main/java/com/elasticthree/ASTCreator/ASTCreator/Helpers/RecursivelyProjectJavaFiles.java
+++ b/src/main/java/com/elasticthree/ASTCreator/ASTCreator/Helpers/RecursivelyProjectJavaFiles.java
@@ -4,7 +4,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.log4j.Logger;
 
@@ -13,9 +15,9 @@ public class RecursivelyProjectJavaFiles {
 	final static Logger logger = Logger.getLogger(RecursivelyProjectJavaFiles.class);
 	final static Logger debugLog = Logger.getLogger("debugLogger");
 	
-	public static List<String> getProjectJavaFiles(String path){
+	public static Map<String, Long> getProjectJavaFiles(String path){
 		
-		List<String> allFiles = new ArrayList<String>();
+		Map<String, Long> allFiles = new HashMap<>();
 		
 		// Java8 lambda expression manner getting recursively all files
 		try {
@@ -35,7 +37,12 @@ public class RecursivelyProjectJavaFiles {
 			 })
 			.filter(p -> p.toFile().getName().endsWith(".java"))
 			.forEach(tmpnam -> {
-					allFiles.add(tmpnam.toString());
+				try {
+					allFiles.put(tmpnam.toString(), Files.lines(tmpnam).count());
+					Files.lines(tmpnam);
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
 			});
 			
 		} catch (IOException e) {


### PR DESCRIPTION
The repository count is very abstract, so it cannot be a reliable metric for our index. Let's add a count-java-lines feature, so that we can know how many java lines we have indexed.
